### PR TITLE
Add get_app_at_slot method to retrieve descriptor for any index

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -204,7 +204,7 @@ jobs:
       fail-fast: false
       matrix:
         commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
-        msrv: ["1.79"] # We're relying on namespaced-features, which
+        msrv: ["1.84"] # We're relying on namespaced-features, which
                        # was released in 1.60
                        #
                        # We also depend on `fixed' which requires rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,6 +187,16 @@ impl BootableRegionDescriptors {
         )
         .unwrap()
     }
+
+    /// Get descriptor for a specific app slot
+    pub fn get_app_at_slot(&self, app_slot: u32) -> Result<AppImageDescriptor, ParseError> {
+        if app_slot >= self.header.num_app_slots {
+            return Err(ParseError::InvalidAppSlot);
+        }
+
+        // can't fail as BootableRegionDescriptors only constructs if all app descriptors are valid
+        AppImageDescriptor::from_region(self.header.app_descriptor_base_address as *const u32, app_slot)
+    }
 }
 
 impl BootableRegionDescriptorHeader {


### PR DESCRIPTION
For the `BootableRegionDescriptors` object to return the `AppImageDescriptor` from an app at any specified index. The new `get_app_at_slot(idx)` method will verify the index is within the number of app slots then return the specified app descriptor.